### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#CodeIgniter Standard Project
+# CodeIgniter Standard Project
 by [Ben Edmunds](http://benedmunds.com)
 
-###Included
+### Included
 * CodeIgniter master as a submodule
   https://github.com/EllisLab/CodeIgniter
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
